### PR TITLE
Update configure script to use correct Fortran settings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,11 +22,12 @@ Author: Vladislav Kim [aut, cre],
 License: EPL
 Depends: R (>= 3.0.0)
 Enhances: slam
-Suggests: BiocStyle, knitr
+Suggests: BiocStyle, knitr, testthat
 URL: http://R-Forge.R-project.org/projects/rsymphony,
         https://projects.coin-or.org/SYMPHONY,
         http://www.coin-or.org/download/source/SYMPHONY/
 biocViews: Infrastructure, ThirdPartyClient
 VignetteBuilder: knitr
 NeedsCompilation: yes
+SystemRequirements: GNU make
 Repository: Bioconductor

--- a/configure
+++ b/configure
@@ -103,9 +103,9 @@ EOF
 		CFLAGS="-w -g -O2" \
 		CXXFLAGS="-w -g -O2" \
 		CC="`${R} CMD config CC`" \
-		CPP="`${R} CMD config CPP`" \
+		#CPP="`${R} CMD config CPP`" \
 		CXX="`${R} CMD config CXX`" \
-		CXXCPP="`${R} CMD config CXXCPP`" \
+		#CXXCPP="`${R} CMD config CXXCPP`" \
 		F77="`${R} CMD config FC`" \
 		FLIBS="`${R} CMD config FLIBS`")
 	    SYMPHONY_LIBS="-lSym -lCgl -lOsiClp -lClp -lOsi -lCoinUtils"


### PR DESCRIPTION
Hi Vlad,

This is in response to the message at https://support.bioconductor.org/p/126113/

It looks like R-devel has removed the `F77` setting from `R CMD config` and now requires using `FC`.  This patch just makes that change, and it seems to compile & check fine for me now.
